### PR TITLE
feat: connect repository API

### DIFF
--- a/app/repositories/page.tsx
+++ b/app/repositories/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"; //로그인 실패할 경우에 리
 import { IconEye, IconCalendar } from "../components/icons";
 import LoadingSpinner from "../components/LoadingSpinner";
 import { mockDeveloperReports } from "@/mock/devReports";
+import { apiGet } from "../lib/api";
 
 //백엔드 API 응답 래퍼 구조
 type ApiResponse<T> = {
@@ -67,12 +68,7 @@ export default function RepositoriesPage() {
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsCheckingAuth(false);
-    fetch("https://api.gitfit.site/api/repositories", {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-      .then((res) => res.json())
+    apiGet("/api/repositories")
       .then((data: ApiResponse<BackendRepo>) => {
         if (!data.result || !Array.isArray(data.result)) return;
         //백엔드를 프론트 타입으로 변환


### PR DESCRIPTION
close #24

### Description
- repositories 페이지의 목데이터를 제거하고 실제 API를 연결했습니다.

### Changes
- API 타입 정의 추가: 백엔드 응답 구조에 맞게 ApiResponse<T> 타입과 BackendRepo 타입 추가
- 목데이터 제거: mockRepositories 배열 삭제
- API 호출 개선: 하드코딩된 fetch 대신 기존 apiGet 유틸리티 사용
- 데이터 변환 로직 수정: 실제 API 응답 필드(full_name, pushed_at)에 맞게 변환 로직 수정

### ETC
- 엔드포인트: GET /api/repositories